### PR TITLE
Fix for 'empty groups' in .yml.

### DIFF
--- a/Redirector/extension.php
+++ b/Redirector/extension.php
@@ -107,7 +107,12 @@ class Extension extends BoltExtension
         // Assign configuration groups to arrays in object
         $configGroups = array('options', 'redirects', 'jits', 'variables');
         foreach($configGroups as $group) {
-            $this->$group = $this->config[$group];
+            if (!empty($this->config[$group])) {
+                $this->$group = $this->config[$group];
+            } else {
+                // Take 'empty groups' from the .yml file into account.
+                $this->$group = array();
+            }
         }
     }
 


### PR DESCRIPTION
The default .yml file defines some 'groups', which are left empty. This throws an error, because the code expects an empty `array()`, while the .yml parses these as `null`.

Tis fix prevents "Array expected"-exceptions thrown in, for example, here: 

```
$self->variables = array_merge($self->variables, array(
```
